### PR TITLE
fix: Fix helm chart default env object

### DIFF
--- a/charts/dbman/Chart.yaml
+++ b/charts/dbman/Chart.yaml
@@ -5,5 +5,5 @@ type: application
 annotations:
   artifacthub.io/operator: 'true'
   artifacthub.io/prerelease: 'true'
-version: 0.123.1
+version: 0.123.2
 appVersion: 0.123.1

--- a/charts/dbman/values.yaml
+++ b/charts/dbman/values.yaml
@@ -58,4 +58,4 @@ tolerations: []
 
 affinity: {}
 
-env: {}
+env: []


### PR DESCRIPTION
Env vars in Deployments expect a slice, not a map. Updated the default values.yaml to reflect that.